### PR TITLE
#add configuration to force build with a jdk6.

### DIFF
--- a/avrilog-java-client/pom.xml
+++ b/avrilog-java-client/pom.xml
@@ -23,7 +23,22 @@
 	     <url>http://nexus.myprocurement.fr/content/repositories/snapshots/</url>
 	  </snapshotRepository>
 	</distributionManagement>
-	 
+
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<configuration>
+						<source>1.6</source>
+						<target>1.6</target>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
+
 	<dependencies>
 		<dependency>
 			<groupId>com.rabbitmq</groupId>


### PR DESCRIPTION
On my computer it was building with a jdl 1.3 style by default.
